### PR TITLE
AL-982: Hide the Chatto supplied input UI

### DIFF
--- a/Chatto/Source/ChatController/ChatViewController.swift
+++ b/Chatto/Source/ChatController/ChatViewController.swift
@@ -132,8 +132,8 @@ public class ChatViewController: UIViewController, UICollectionViewDataSource, U
         self.inputContainer.addConstraint(NSLayoutConstraint(item: self.inputContainer, attribute: .Leading, relatedBy: .Equal, toItem: inputView, attribute: .Leading, multiplier: 1, constant: 0))
         self.inputContainer.addConstraint(NSLayoutConstraint(item: self.inputContainer, attribute: .Bottom, relatedBy: .Equal, toItem: inputView, attribute: .Bottom, multiplier: 1, constant: 0))
         self.inputContainer.addConstraint(NSLayoutConstraint(item: self.inputContainer, attribute: .Trailing, relatedBy: .Equal, toItem: inputView, attribute: .Trailing, multiplier: 1, constant: 0))
-        // AL-982: Hide the default Chatto input UI.
-        self.inputContainer.addConstraint(NSLayoutConstraint(item: self.inputContainer, attribute: .Height, relatedBy: .Equal, toItem: nil, attribute: .NotAnAttribute, multiplier: 1, constant: 0))
+
+        hideInputContainer(false)
 
         self.keyboardTracker = KeyboardTracker(viewController: self, inputContainer: self.inputContainer, inputContainerBottomContraint: self.inputContainerBottomConstraint, notificationCenter: self.notificationCenter)
     }

--- a/Chatto/Source/ChatController/ChatViewController.swift
+++ b/Chatto/Source/ChatController/ChatViewController.swift
@@ -110,7 +110,6 @@ public class ChatViewController: UIViewController, UICollectionViewDataSource, U
     }
 
     private var inputContainerBottomConstraint: NSLayoutConstraint!
-    private var topConstraint: NSLayoutConstraint!
     private var heightConstraint: NSLayoutConstraint!
     private func addInputViews() {
         self.inputContainer = UIView(frame: CGRect.zero)
@@ -127,8 +126,7 @@ public class ChatViewController: UIViewController, UICollectionViewDataSource, U
         let inputView = self.createChatInputView()
         self.inputContainer.addSubview(inputView)
         heightConstraint = NSLayoutConstraint(item: self.inputContainer, attribute: .Height, relatedBy: .Equal, toItem: nil, attribute: .NotAnAttribute, multiplier: 1, constant: 0)
-        topConstraint = NSLayoutConstraint(item: self.inputContainer, attribute: .Top, relatedBy: .Equal, toItem: inputView, attribute: .Top, multiplier: 1, constant: 0)
-        self.inputContainer.addConstraint(topConstraint)
+        self.inputContainer.addConstraint(NSLayoutConstraint(item: self.inputContainer, attribute: .Top, relatedBy: .Equal, toItem: inputView, attribute: .Top, multiplier: 1, constant: 0))
         self.inputContainer.addConstraint(NSLayoutConstraint(item: self.inputContainer, attribute: .Leading, relatedBy: .Equal, toItem: inputView, attribute: .Leading, multiplier: 1, constant: 0))
         self.inputContainer.addConstraint(NSLayoutConstraint(item: self.inputContainer, attribute: .Bottom, relatedBy: .Equal, toItem: inputView, attribute: .Bottom, multiplier: 1, constant: 0))
         self.inputContainer.addConstraint(NSLayoutConstraint(item: self.inputContainer, attribute: .Trailing, relatedBy: .Equal, toItem: inputView, attribute: .Trailing, multiplier: 1, constant: 0))
@@ -158,8 +156,7 @@ public class ChatViewController: UIViewController, UICollectionViewDataSource, U
     }
 
     public func hideInputContainer(hide: Bool) {
-        topConstraint.active = !hide
-        heightConstraint.active = hide
+        self.heightConstraint.active = hide
         self.inputContainer.setNeedsUpdateConstraints()
     }
 

--- a/Chatto/Source/ChatController/ChatViewController.swift
+++ b/Chatto/Source/ChatController/ChatViewController.swift
@@ -114,6 +114,7 @@ public class ChatViewController: UIViewController, UICollectionViewDataSource, U
         self.inputContainer = UIView(frame: CGRect.zero)
         self.inputContainer.autoresizingMask = .None
         self.inputContainer.translatesAutoresizingMaskIntoConstraints = false
+        self.inputContainer.clipsToBounds = true
         self.view.addSubview(self.inputContainer)
         self.view.addConstraint(NSLayoutConstraint(item: self.inputContainer, attribute: .Top, relatedBy: .GreaterThanOrEqual, toItem: self.topLayoutGuide, attribute: .Bottom, multiplier: 1, constant: 0))
         self.view.addConstraint(NSLayoutConstraint(item: self.view, attribute: .Leading, relatedBy: .Equal, toItem: self.inputContainer, attribute: .Leading, multiplier: 1, constant: 0))
@@ -127,6 +128,8 @@ public class ChatViewController: UIViewController, UICollectionViewDataSource, U
         self.inputContainer.addConstraint(NSLayoutConstraint(item: self.inputContainer, attribute: .Leading, relatedBy: .Equal, toItem: inputView, attribute: .Leading, multiplier: 1, constant: 0))
         self.inputContainer.addConstraint(NSLayoutConstraint(item: self.inputContainer, attribute: .Bottom, relatedBy: .Equal, toItem: inputView, attribute: .Bottom, multiplier: 1, constant: 0))
         self.inputContainer.addConstraint(NSLayoutConstraint(item: self.inputContainer, attribute: .Trailing, relatedBy: .Equal, toItem: inputView, attribute: .Trailing, multiplier: 1, constant: 0))
+        // AL-982: Hide the default Chatto input UI.
+        self.inputContainer.addConstraint(NSLayoutConstraint(item: self.inputContainer, attribute: .Height, relatedBy: .Equal, toItem: nil, attribute: .NotAnAttribute, multiplier: 1, constant: 0))
 
         self.keyboardTracker = KeyboardTracker(viewController: self, inputContainer: self.inputContainer, inputContainerBottomContraint: self.inputContainerBottomConstraint, notificationCenter: self.notificationCenter)
     }

--- a/Chatto/Source/ChatController/ChatViewController.swift
+++ b/Chatto/Source/ChatController/ChatViewController.swift
@@ -110,6 +110,8 @@ public class ChatViewController: UIViewController, UICollectionViewDataSource, U
     }
 
     private var inputContainerBottomConstraint: NSLayoutConstraint!
+    private var topConstraint: NSLayoutConstraint!
+    private var heightConstraint: NSLayoutConstraint!
     private func addInputViews() {
         self.inputContainer = UIView(frame: CGRect.zero)
         self.inputContainer.autoresizingMask = .None
@@ -124,7 +126,9 @@ public class ChatViewController: UIViewController, UICollectionViewDataSource, U
 
         let inputView = self.createChatInputView()
         self.inputContainer.addSubview(inputView)
-        self.inputContainer.addConstraint(NSLayoutConstraint(item: self.inputContainer, attribute: .Top, relatedBy: .Equal, toItem: inputView, attribute: .Top, multiplier: 1, constant: 0))
+        heightConstraint = NSLayoutConstraint(item: self.inputContainer, attribute: .Height, relatedBy: .Equal, toItem: nil, attribute: .NotAnAttribute, multiplier: 1, constant: 0)
+        topConstraint = NSLayoutConstraint(item: self.inputContainer, attribute: .Top, relatedBy: .Equal, toItem: inputView, attribute: .Top, multiplier: 1, constant: 0)
+        self.inputContainer.addConstraint(topConstraint)
         self.inputContainer.addConstraint(NSLayoutConstraint(item: self.inputContainer, attribute: .Leading, relatedBy: .Equal, toItem: inputView, attribute: .Leading, multiplier: 1, constant: 0))
         self.inputContainer.addConstraint(NSLayoutConstraint(item: self.inputContainer, attribute: .Bottom, relatedBy: .Equal, toItem: inputView, attribute: .Bottom, multiplier: 1, constant: 0))
         self.inputContainer.addConstraint(NSLayoutConstraint(item: self.inputContainer, attribute: .Trailing, relatedBy: .Equal, toItem: inputView, attribute: .Trailing, multiplier: 1, constant: 0))
@@ -151,6 +155,12 @@ public class ChatViewController: UIViewController, UICollectionViewDataSource, U
             self.updateQueue.start()
             self.isFirstLayout = false
         }
+    }
+
+    public func hideInputContainer(hide: Bool) {
+        topConstraint.active = !hide
+        heightConstraint.active = hide
+        self.inputContainer.setNeedsUpdateConstraints()
     }
 
     private func adjustCollectionViewInsets() {


### PR DESCRIPTION
SUMMARY:
Hides the Chatto input container so that only our ButtonInputView is visible. Does this by adding a height constraint to ChatViewController's inputContainer and keeping track of the top constraint in a local ivar. The new hideInputContainer() toggle the active constraint depending if we want the inputContainer visible or not

TEST:
Launch app and verify that only the ButtonInputView is visible and that the Chatto input container and the enclosed buttons (Send, etc) are not visible. Also verify that the table with the conversation bubbles bottom edge lines up with our ButtonInputView's top.
